### PR TITLE
fix(vitestGlobals): Include 'test' global in Vitest ESLint configuration

### DIFF
--- a/flat.js
+++ b/flat.js
@@ -6,6 +6,7 @@ export default function vitestGlobals() {
         vi: true,
         describe: true,
         it: true,
+        test: true,
         expect: true,
         beforeEach: true,
         afterEach: true,


### PR DESCRIPTION
This PR adds the missing test global variable to the ESLint FlatConfig for Vitest, resolving the 'test' is not defined error (no-undef) in test files addressing the issue #2 

### Changes
- Added test: true to the globals object in flat.js.
- Ensures ESLint recognizes the test keyword (common in Vitest)

### Why this matters
Vitest [officially supports](https://vitest.dev/api/) test as an alias for it, and the config should reflect this.

### Related Issue
Closes #2 